### PR TITLE
Fixes filemode on swap filepath

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Make sure swapfile has proper permissions.
   file:
     path: "{{ swap_path }}"
-    mode: 600
+    mode: "600"
 
 - name: Make sure there is swap area.
   command: "mkswap {{ swap_path }}"


### PR DESCRIPTION
Double-quoting the octal mode to prevent Ansible from intrepreting it
incorrectly. The task now enforces 'rw' for root, and no access for
group or others. Fixes #1.